### PR TITLE
try to enable click anywhere in Geo mode

### DIFF
--- a/src/components/fx/click.js
+++ b/src/components/fx/click.js
@@ -21,7 +21,11 @@ module.exports = function click(gd, evt, subplot) {
     if(evt && evt.target) {
         if(gd._hoverdata) {
             data = gd._hoverdata;
-        } else if(clickmode.indexOf('anywhere') > -1) {
+        } else if(gd._fullLayout.geo){
+            var lat = gd._fullLayout.geo._subplot.xaxis.p2c();
+            var lon = gd._fullLayout.geo._subplot.yaxis.p2c();
+            data = [{lat: lat, lon: lon}];
+        }else if(clickmode.indexOf('anywhere') > -1) {
             var xaxis = gd._fullLayout.xaxis;
             var yaxis = gd._fullLayout.yaxis;
             var bb = evt.target.getBoundingClientRect();

--- a/src/components/fx/click.js
+++ b/src/components/fx/click.js
@@ -21,17 +21,20 @@ module.exports = function click(gd, evt, subplot) {
     if(evt && evt.target) {
         if(gd._hoverdata) {
             data = gd._hoverdata;
-        } else if(gd._fullLayout.geo){
-            var lat = gd._fullLayout.geo._subplot.xaxis.p2c();
-            var lon = gd._fullLayout.geo._subplot.yaxis.p2c();
-            data = [{lat: lat, lon: lon}];
         }else if(clickmode.indexOf('anywhere') > -1) {
-            var xaxis = gd._fullLayout.xaxis;
-            var yaxis = gd._fullLayout.yaxis;
-            var bb = evt.target.getBoundingClientRect();
-            var x = xaxis.p2d(evt.clientX - bb.left);
-            var y = yaxis.p2d(evt.clientY - bb.top);
-            data = [{x: x, y: y}];
+            if(gd._fullLayout.geo){
+                var lat = gd._fullLayout.geo._subplot.xaxis.p2c();
+                var lon = gd._fullLayout.geo._subplot.yaxis.p2c();
+                data = [{lat: lat, lon: lon}];
+            }
+            else{
+                var xaxis = gd._fullLayout.xaxis;
+                var yaxis = gd._fullLayout.yaxis;
+                var bb = evt.target.getBoundingClientRect();
+                var x = xaxis.p2d(evt.clientX - bb.left);
+                var y = yaxis.p2d(evt.clientY - bb.top);
+                data = [{x: x, y: y}];
+            }
         }
         if(data) {
             if(annotationsDone && annotationsDone.then) {


### PR DESCRIPTION
The original [PR](https://github.com/plotly/plotly.js/pull/5443) will break when one clicks "anywhere" on the Map figure. This PR fix it:

Basic test case with dev tools:

```javascript
       var TESTER = Tabs.getGraph()

        var data = [{
            type: 'scattergeo',
            lat: [ 40.7127, 51.5072 ],
            lon: [ -74.0059, 0.1275 ],
            mode: 'lines',
            line:{
                width: 2,
                color: 'blue'
            }
        }];

        var layout = {
            title: 'London to NYC Great Circle',
            showlegend: false,
            geo: {
                resolution: 50,
                showland: true,
                showlakes: true,
                landcolor: 'rgb(204, 204, 204)',
                countrycolor: 'rgb(204, 204, 204)',
                lakecolor: 'rgb(255, 255, 255)',
                projection: {
                    type: 'equirectangular'
                },
                coastlinewidth: 2,
                lataxis: {
                    range: [ 20, 60 ],
                    showgrid: true,
                    tickmode: 'linear',
                    dtick: 10
                },
                lonaxis:{
                    range: [-100, 20],
                    showgrid: true,
                    tickmode: 'linear',
                    dtick: 20
                }
            },
            clickmode: "event+anywhere"
        };

        Plotly.newPlot(TESTER, data, layout);

        TESTER.on('plotly_click', function(clickData) {
            console.log(clickData);
            var x = clickData["points"][0]["x"];
        });

```